### PR TITLE
Added policies to pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ class CDManifest : Manifest {
     }
 }
 
-new CDManifest();
+new CDManifest()
 ```
 
 Full examples can be found in the examples directory.
@@ -197,4 +197,7 @@ kapitan -f your-manifest-filename.csx -c BuildNumber=2.0.0
 - Pulumi makes the editing experience much more friendly, but requires you to set well-known things that can be included in the abstraction (like API versions, etc). It's also unclear that we could 
 - CDK8S handles the editing experience well, but it relies on a scope that cross-cuts through the entire stack, and also seems to have the same leaky abstractions as Pulumi. Parameterization is also unclear.
 
+## FAQ
+### Why do my script manifests fail to export a manifest?
+The script manifests must return a Manifest object as the last instruction. If a semicolon is placed at the end of the line, it is treated as a full statement and nothing is returned.
  

--- a/examples/configuration/compiled/Kapitan.Demos.Configuration/Kapitan.Demos.Configuration.csproj
+++ b/examples/configuration/compiled/Kapitan.Demos.Configuration/Kapitan.Demos.Configuration.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Kapitan.Core" Version="2.0.0" />
+    <PackageReference Include="Kapitan.Kubernetes" Version="2.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/examples/configuration/compiled/Kapitan.Demos.Configuration/Manifest.cs
+++ b/examples/configuration/compiled/Kapitan.Demos.Configuration/Manifest.cs
@@ -1,0 +1,40 @@
+﻿using System;
+
+namespace Kapitan.Demos.Configuration
+{
+    public class Manifest : Kapitan.Core.Manifest
+    {
+        public override void ConfigureItems(Dictionary<string, string> configuration)
+        {
+            Add(
+                new Deployment
+                {
+                    metadata = new ObjectMeta()
+                    {
+                        name = "helloworld",
+                        annotations = new Dictionary<string, string> {
+                            { "manifest", configuration["Invocation:ManifestSource"] },
+                            { "generated-by", configuration["USERNAME"] }
+                        }
+                    },
+                    spec = new DeploymentSpec()
+                    {
+                        template = new PodTemplateSpec()
+                        {
+                            spec = new PodSpec()
+                            {
+                                containers = new List<Container>() {
+                    new Container() {
+                        image = $"busybox:{configuration["BuildNumber"]}",
+                        name = "hello",
+                        command = new List<string> { "sh", "-c", "echo \"Hello, Kubernetes!\" && sleep 3600" }
+                    }
+                            },
+                                restartPolicy = "OnFailure"
+                            }
+                        }
+                    }
+                });
+        }
+    }
+}

--- a/examples/configuration/script/manifest.csx
+++ b/examples/configuration/script/manifest.csx
@@ -1,0 +1,35 @@
+#r "nuget: Kapitan.Kubernetes, 2.0.0"
+using Kapitan.Core;
+using Kapitan.Kubernetes.Apps.V1;
+using Kapitan.Kubernetes.Core.V1;
+
+class CDManifest : Manifest {
+    public override void ConfigureItems(Dictionary<string, string> configuration) {
+        Add(
+            new Deployment { 
+            metadata = new ObjectMeta() { 
+                name = "helloworld",
+                annotations = new Dictionary<string, string> {
+                    // { "manifest", configuration["Invocation:ManifestSource"] },
+                    { "generated-by", configuration["USERNAME"] }
+                } 
+            },
+            spec = new DeploymentSpec() {
+                template = new PodTemplateSpec() {
+                    spec = new PodSpec() {
+                        containers = new List<Container>() {
+                            new Container() {
+                                image = $"busybox:{configuration["BuildNumber"]}",
+                                name = "hello",
+                                command = new List<string> { "sh", "-c", "echo \"Hello, Kubernetes!\" && sleep 3600" }
+                            }
+                        },
+                        restartPolicy = "OnFailure"
+                    }
+                }
+            }
+        });
+    }
+}
+
+new CDManifest()

--- a/examples/getting-started/compiled/Kapitan.Demos.GettingStarted/Kapitan.Demos.GettingStarted.csproj
+++ b/examples/getting-started/compiled/Kapitan.Demos.GettingStarted/Kapitan.Demos.GettingStarted.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Kapitan.Core" Version="2.0.0" />
+    <PackageReference Include="Kapitan.Kubernetes" Version="2.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/examples/getting-started/compiled/Kapitan.Demos.GettingStarted/Manifest.cs
+++ b/examples/getting-started/compiled/Kapitan.Demos.GettingStarted/Manifest.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using Kapitan.Kubernetes.Core.V1;
+using Kapitan.Kubernetes.Apps.V1;
+using System.Collections.Generic;
+
+[assembly: Kapitan.Core.KapitanManifest(typeof(Kapitan.Demos.GettingStarted.Manifest))]
+
+namespace Kapitan.Demos.GettingStarted
+{
+    public class Manifest : Kapitan.Core.Manifest
+    {
+        public Manifest()
+        {
+            this.Add(new Deployment()
+            {
+                metadata = new ObjectMeta
+                {
+                    name = "helloworld"
+                },
+                spec = new DeploymentSpec
+                {
+                    selector = new LabelSelector
+                    {
+                        matchLabels = new { app = "helloworld" }
+                    },
+                    template = new PodTemplateSpec
+                    {
+                        metadata = new ObjectMeta()
+                        {
+                            labels = new { app = "helloworld" }
+                        },
+                        spec = new PodSpec
+                        {
+                            containers = new List<Container> {
+                        new Container {
+                            image = "nginx",
+                            name = "hello",
+                            ports = new List<ContainerPort> {
+                                new ContainerPort { containerPort = 80 }
+                            }
+                        }
+                    },
+                            restartPolicy = "OnFailure"
+                        }
+                    }
+                }
+            });
+
+            this.Add(new Service
+            {
+                metadata = new ObjectMeta
+                {
+                    name = "helloworld",
+                },
+                spec = new ServiceSpec
+                {
+                    type = "ClusterIP",
+                    selector = new { app = "helloworld" }
+                }
+            });
+        }
+    }
+}

--- a/examples/getting-started/script/manifest.csx
+++ b/examples/getting-started/script/manifest.csx
@@ -11,7 +11,7 @@ new Kapitan.Core.Manifest() {
         spec = new DeploymentSpec {
             selector = new LabelSelector {
                 matchLabels = new { app = "helloworld" }
-            }
+            },
             template = new PodTemplateSpec {
                 metadata = new ObjectMeta() {
                     labels = new { app = "helloworld" }

--- a/examples/policies/script/README.md
+++ b/examples/policies/script/README.md
@@ -1,0 +1,6 @@
+## Policies
+
+### How to Run
+```
+kapitan -f manifest.csx -p policies.csx
+```

--- a/examples/policies/script/manifest.csx
+++ b/examples/policies/script/manifest.csx
@@ -1,0 +1,40 @@
+#r "nuget: Kapitan.Kubernetes, 2.1.0"
+
+using Kapitan.Kubernetes.Apps.V1;
+using Kapitan.Kubernetes.Core.V1;
+
+new Kapitan.Core.Manifest() {
+    new Deployment() {
+        metadata = new ObjectMeta {
+            name = "helloworld",
+            @namespace = "default"
+        },
+        spec = new DeploymentSpec {
+            template = new PodTemplateSpec {
+                spec = new PodSpec {
+                    containers = new List<Container> {
+                        new Container {
+                            image = "busybox",
+                            name = "hello",
+                            command = new List<string> { "sh", "-c" },
+                            ports = new List<ContainerPort> {
+                                new ContainerPort { containerPort = 80 }
+                            }
+                        }
+                    },
+                    restartPolicy = "OnFailure"
+                }
+            }
+        }
+    },
+    new Service {
+        metadata = new ObjectMeta {
+            name = "helloworld",
+            @namespace = "default"
+        },
+        spec = new ServiceSpec {
+            type = "ClusterIP",
+            selector = new { app = "helloworld" }
+        }
+    }
+}

--- a/examples/policies/script/policies.csx
+++ b/examples/policies/script/policies.csx
@@ -1,0 +1,37 @@
+#r "nuget: Kapitan.Core, 2.1.0"
+#r "nuget: Kapitan.Kubernetes, 2.1.0"
+
+using System.Collections.Generic;
+using Kapitan.Core;
+using Kapitan.Kubernetes.Apps.V1;
+
+class AnnotateObjectsPolicy : IPolicy
+{
+    public void Evaluate(IManifestObject manifestObject, Dictionary<string, string> configuration)
+    {
+        dynamic resource = manifestObject;
+
+        try {
+            if (resource.metadata.annotations == null) resource.metadata.annotations = new Dictionary<string, string>();
+                resource.metadata.annotations.Add("kapitan.dev/manifest", configuration["Invocation.ManifestSource"]);
+        }
+        catch (Exception ex) { Console.Error.WriteLine(ex.Message); }
+    }
+}
+
+class EnforcePullPolicyPolicy : IPolicy
+{
+    public void Evaluate(IManifestObject manifestObject, Dictionary<string, string> configuration)
+    {
+        if (manifestObject is Deployment deployment) {
+            foreach (var container in deployment.spec.template.spec.containers) {
+                container.imagePullPolicy = "IfNotPresent";
+            }
+        }
+    }
+}
+
+new IPolicy[] {
+    new AnnotateObjectsPolicy(),
+    new EnforcePullPolicyPolicy()
+}

--- a/src/Kapitan.Core/ConfigWrappedString.cs
+++ b/src/Kapitan.Core/ConfigWrappedString.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Kapitan.Core
+{
+    public class ConfigWrappedString : WrappedString
+    {
+        public ConfigWrappedString(string value = default) : base(value) { }
+
+        public static implicit operator string(ConfigWrappedString v)
+        {
+            return v.Value;
+        }
+
+        public static implicit operator ConfigWrappedString(string v)
+        {
+            if (string.IsNullOrEmpty(v)) return null;
+
+            return new ConfigWrappedString(v);
+        }
+
+        public string ConfigKey { get; set; }
+
+        public static ConfigWrappedString FromConfig(string key)
+        {
+            return new ConfigWrappedString() { ConfigKey = key };
+        }
+
+        public string GetValue(Dictionary<string, string> config)
+        {
+            return string.IsNullOrEmpty(Value) ? config[ConfigKey] : Value;
+        }
+    }
+}

--- a/src/Kapitan.Core/IPolicy.cs
+++ b/src/Kapitan.Core/IPolicy.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Kapitan.Core
+{
+    public interface IPolicy
+    {
+        void Evaluate(IManifestObject manifestObject, Dictionary<string, string> configuration);
+    }
+}

--- a/src/Kapitan.Core/KapitanPolicySetAttribute.cs
+++ b/src/Kapitan.Core/KapitanPolicySetAttribute.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace Kapitan.Core
 {
-    [AttributeUsage(AttributeTargets.Assembly)]
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
     public class KapitanPolicySetAttribute : Attribute
     {
         public KapitanPolicySetAttribute(Type policySetType)

--- a/src/Kapitan.Core/KapitanPolicySetAttribute.cs
+++ b/src/Kapitan.Core/KapitanPolicySetAttribute.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Kapitan.Core
+{
+    [AttributeUsage(AttributeTargets.Assembly)]
+    public class KapitanPolicySetAttribute : Attribute
+    {
+        public KapitanPolicySetAttribute(Type policySetType)
+        {
+            PolicySetType = policySetType;
+        }
+
+        public Type PolicySetType { get; set; }
+
+        /// <summary>
+        /// The Name of the PolicySet attribute can be used to choose a specific policy set from a compiled library
+        /// </summary>
+        public string Name { get; set; }
+    }
+}

--- a/src/Kapitan.Core/PolicySet.cs
+++ b/src/Kapitan.Core/PolicySet.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Kapitan.Core
+{
+    public class PolicySet : List<IPolicy>
+    {
+        public void Add(PolicySet policies)
+        {
+            AddRange(policies);
+        }
+    }
+}

--- a/src/Kapitan/Configuration/GlobalOptionsManifestConfigurationProvider.cs
+++ b/src/Kapitan/Configuration/GlobalOptionsManifestConfigurationProvider.cs
@@ -17,6 +17,7 @@ namespace Kapitan.Configuration
         {
             values.Add("Invocation.EmitCrds", program.EmitCrds.ToString());
             values.Add("Invocation.Verbose", program.Verbose.ToString());
+            values.Add("Invocation.ManifestSource", program.ManifestSource);
 
             return values;
         }

--- a/src/Kapitan/Loaders/CompiledPolicySetLoader.cs
+++ b/src/Kapitan/Loaders/CompiledPolicySetLoader.cs
@@ -1,0 +1,55 @@
+﻿using Kapitan.Core;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Kapitan.Loaders
+{
+    public class CompiledPolicySetLoader : IPolicySetLoader
+    {
+        public string PolicySetName { get; set; }
+        public FileInfo Source { get; set; }
+
+        public async Task<IEnumerable<IPolicy>> Load()
+        {
+            var assembly = Assembly.LoadFrom(Source.FullName);
+            Type policySetType = null;
+            var attributes = assembly.GetCustomAttributes<KapitanPolicySetAttribute>();
+            if (!string.IsNullOrEmpty(PolicySetName)) attributes = attributes.Where(attr => attr.Name == PolicySetName);
+
+            if (attributes.Skip(1).Any()) throw new InvalidOperationException("Multiple policy sets were found. Please specify the policy set name using the --policy-set attribute");
+            else if (!attributes.Any())
+            {
+                // No declared manifest type was detected, so we will load a manifest by convention
+                // if it is the one and only one type inheriting from Manifest
+                try
+                {
+                    policySetType = assembly.GetExportedTypes().Single(t => typeof(PolicySet).IsAssignableFrom(t));
+                }
+                catch (InvalidOperationException iopEx)
+                {
+                    throw new MissingManifestException("No policy set could be loaded from the provided assembly. Please make sure that either there is a single class inheriting from PolicySet publically available, or that the assembly is decorated with the KapitanPolicySetAttribute");
+                }
+            }
+            else
+            {
+                policySetType = attributes.First().PolicySetType;
+            }
+
+            if (!typeof(PolicySet).IsAssignableFrom(policySetType))
+            {
+                throw new MissingManifestException("The type specified by the KapitanPolicySetAttribute is not a descendant of the PolicySet type");
+            }
+            else if (policySetType.GetConstructors().SingleOrDefault(ci => ci.GetParameters().Length == 0) == null)
+            {
+                throw new MissingManifestException("The specified PolicySet type has no parameterless constructors");
+            }
+
+            return Activator.CreateInstance(policySetType) as PolicySet;
+        }
+    }
+}

--- a/src/Kapitan/Loaders/IPolicySetLoader.cs
+++ b/src/Kapitan/Loaders/IPolicySetLoader.cs
@@ -1,0 +1,16 @@
+﻿using Kapitan.Core;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Kapitan.Loaders
+{
+    public interface IPolicySetLoader
+    {
+        Task<IEnumerable<IPolicy>> Load();
+
+        public FileInfo Source { get; set; }
+    }
+}

--- a/src/Kapitan/Loaders/PolicySetLoaderFactory.cs
+++ b/src/Kapitan/Loaders/PolicySetLoaderFactory.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Text;
+
+namespace Kapitan.Loaders
+{
+    public static class PolicySetLoaderFactory
+    {
+        public static IPolicySetLoader BuildPolicySetLoader(FileInfo file, bool isVerbose, string policySetName)
+        {
+            try
+            {
+                AssemblyName.GetAssemblyName(file.FullName);
+                return new CompiledPolicySetLoader() { Source = file, PolicySetName = policySetName };
+            }
+            catch (BadImageFormatException)
+            {
+                return new ScriptPolicySetLoader() { Source = file, Verbose = isVerbose };
+            }
+        }
+    }
+}

--- a/src/Kapitan/Loaders/ScriptLoader.cs
+++ b/src/Kapitan/Loaders/ScriptLoader.cs
@@ -1,0 +1,30 @@
+﻿using Dotnet.Script;
+using Dotnet.Script.Core;
+using Dotnet.Script.Core.Commands;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Kapitan.Loaders
+{
+    public class ScriptLoader<T>
+    {
+        public bool Verbose { get; set; }
+
+        public async Task<T> Load(FileInfo file)
+        {
+            var console = new ScriptConsole(Console.Error, Console.In, Console.Error);
+            var logger = LogHelper.CreateLogFactory(Verbose ? "debug" : "info");
+
+            var manifestSource = File.ReadAllText(file.FullName);
+
+            var command = new ExecuteCodeCommand(console, logger);
+            var options = new ExecuteCodeCommandOptions(manifestSource, file.DirectoryName, new string[] { }, Microsoft.CodeAnalysis.OptimizationLevel.Debug, true, null);
+
+            var retval = await command.Execute<T>(options);
+            return retval;
+        }
+    }
+}

--- a/src/Kapitan/Loaders/ScriptManifestLoader.cs
+++ b/src/Kapitan/Loaders/ScriptManifestLoader.cs
@@ -11,22 +11,11 @@ using System.Threading.Tasks;
 
 namespace Kapitan.Loaders
 {
-    public class ScriptManifestLoader : IManifestLoader
+    public class ScriptManifestLoader : ScriptLoader<Manifest>, IManifestLoader
     {
-        public bool Verbose { get; set; }
         public async Task<Manifest> LoadManifest(FileInfo file)
         {
-            var console = new ScriptConsole(Console.Error, Console.In, Console.Error);
-            var logger = LogHelper.CreateLogFactory(Verbose ? "debug" : "info");
-
-            var manifestSource = File.ReadAllText(file.FullName);
-
-            var command = new ExecuteCodeCommand(console, logger);
-            var options = new ExecuteCodeCommandOptions(manifestSource, file.DirectoryName, new string[] { }, Microsoft.CodeAnalysis.OptimizationLevel.Debug, true, null);
-
-            var manifest = await command.Execute<Manifest>(options);
-
-            return manifest;
+            return await Load(file);
         }
     }
 }

--- a/src/Kapitan/Loaders/ScriptPolicySetLoader.cs
+++ b/src/Kapitan/Loaders/ScriptPolicySetLoader.cs
@@ -1,0 +1,19 @@
+﻿using Kapitan.Core;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Kapitan.Loaders
+{
+    public class ScriptPolicySetLoader : ScriptLoader<IEnumerable<IPolicy>>, IPolicySetLoader
+    {
+        public FileInfo Source { get; set; }
+
+        public async Task<IEnumerable<IPolicy>> Load()
+        {
+            return await Load(Source);
+        }
+    }
+}

--- a/src/Kapitan/ManifestPipeline.cs
+++ b/src/Kapitan/ManifestPipeline.cs
@@ -12,12 +12,14 @@ namespace Kapitan
         private readonly ManifestProcessor processor;
         private readonly IManifestLoader loader;
         private readonly ManifestSerializer serializer;
+        private readonly PolicySetEvaluator policySet;
 
-        public ManifestPipeline(ManifestProcessor processor, IManifestLoader loader, ManifestSerializer serializer)
+        public ManifestPipeline(ManifestProcessor processor, IManifestLoader loader, ManifestSerializer serializer, PolicySetEvaluator policySet)
         {
             this.processor = processor;
             this.loader = loader;
             this.serializer = serializer;
+            this.policySet = policySet;
         }
 
         public async Task ExecutePipeline(FileInfo file)
@@ -26,6 +28,8 @@ namespace Kapitan
 
             var config = processor.BuildConfiguration();
             processor.Process(manifest, config);
+
+            await policySet.Evaluate(manifest, config);
 
             var output = serializer.ProcessManifest(manifest);
 

--- a/src/Kapitan/PolicySetEvaluator.cs
+++ b/src/Kapitan/PolicySetEvaluator.cs
@@ -1,0 +1,35 @@
+﻿using Kapitan.Core;
+using Kapitan.Loaders;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Kapitan
+{
+    public class PolicySetEvaluator
+    {
+        private readonly IPolicySetLoader loader;
+
+        public PolicySetEvaluator(IPolicySetLoader loader)
+        {
+            this.loader = loader;
+        }
+
+        public async Task Evaluate(Manifest manifest, Dictionary<string, string> configuration)
+        {
+            var policySet = await loader?.Load();
+            if (policySet != null)
+            {
+                foreach (IPolicy policy in policySet)
+                {
+                    foreach (IManifestObject obj in manifest)
+                    {
+                        policy.Evaluate(obj, configuration);
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Policies allow the manifest to be modified at runtime in order to ensure certain standards are used. These don't require anything to be set in the manifest, and can be pulled from a different repository